### PR TITLE
Don't ignore files from pre-commit

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -26,7 +26,7 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    
+
     services:
       postgres:
         image: postgres:12
@@ -36,7 +36,7 @@ jobs:
           POSTGRES_DB: postgres
         ports: ['9932:5432']
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
-        
+
     strategy:
       max-parallel: 4
       matrix:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,3 @@
-exclude: 'build|compose|dist|docs|migrations|requirements|.git|.github|.tox'
 default_stages: [commit]
 
 repos:

--- a/tox.ini
+++ b/tox.ini
@@ -13,4 +13,4 @@ basepython =
     py39: python3.9
     py38: python3.8
     py37: python3.7
-    
+


### PR DESCRIPTION
pre-commit only checks files known to git, so half the entries in the `exclude` parameter here were unnecessary. As for the others - seems worthwhile to allow pre-commit to run on them and fix trailing whitespace at least.