### PR TITLE
Fix: incorrect type for output_field argument of generate_series function

### DIFF
--- a/django_generate_series/models.py
+++ b/django_generate_series/models.py
@@ -386,7 +386,7 @@ def generate_series(
     step: Optional[Union[int, str]] = None,
     span: Optional[int] = 1,
     *,
-    output_field: models.Field,
+    output_field: Type[models.Field],
     include_id: Optional[bool] = False,
     max_digits: Optional[Union[int, None]] = None,
     decimal_places: Optional[Union[int, None]] = None,


### PR DESCRIPTION
# Explanation
`output_field` argument of `generate_series` function should be a child class of `models.Field`. It is used in `django_generate_series.models._make_model_class` function to validate whether the `output_field` is of supported fields, where `issubclass` is used for checking. https://github.com/jacklinke/django-generate-series/blob/ae419b9d761b93b59632269dc54252c135ea3fb9/django_generate_series/models.py#L407

However, the first argument of `issubclass` must be a class, not an instance. Therefore, the typing is incorrect here.